### PR TITLE
fingerprint & storaged

### DIFF
--- a/sparse/etc/sailfish-fpd/50-settings-ganges.ini
+++ b/sparse/etc/sailfish-fpd/50-settings-ganges.ini
@@ -7,7 +7,8 @@ fphal_max_fingerprints_quirk    = 5
 
 mass_remove_single_notify_quirk = 0
 set_active_group_twice_quirk    = 0
+set_active_group_always_quirk   = 1
 skip_post_enroll_quirk          = 0
-skip_enumerate_quirk            = 1
+skip_enumerate_quirk            = 0
 no_cancel_notification_quirk    = 0
 

--- a/sparse/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/disabled_services.rc
@@ -17,3 +17,5 @@ service lmkd /system/bin/lmkd_HYBRIS_DISABLED
 service vold /system/bin/vold_HYBRIS_DISABLED
 
 service wificond /system/bin/wificond_HYBRIS_DISABLED
+
+service storaged /system/bin/storaged_HYBRIS_DISABLED


### PR DESCRIPTION
[fingerprint] Disable enumerate quirk and enable new set_active_group_always_quirk. JB#46531
[configs] Disable unneeded Android storaged service. JB#46519