### PR TITLE
flash-partition: Allow flashing on both SDM630 and SDM636 platforms.

### DIFF
--- a/sparse/var/lib/flash-partition/device-info
+++ b/sparse/var/lib/flash-partition/device-info
@@ -1,4 +1,4 @@
-CPUCHECK_STRING="Qualcomm Technologies, Inc SDM630"
+CPUCHECK_STRING="Qualcomm Technologies, Inc SDM63.$"
 
 # Because of flash-partition checks 1 needs to be defined
 # Others can go with parition numbers


### PR DESCRIPTION
[flash-partition] Allow flashing on both SDM630 and SDM636 platforms. Fixes JB#46830