### PR TITLE
configs: Remove firmware symbolic links.

### DIFF
--- a/sparse/etc/firmware
+++ b/sparse/etc/firmware
@@ -1,1 +1,0 @@
-/odm/firmware

--- a/sparse/lib/firmware
+++ b/sparse/lib/firmware
@@ -1,1 +1,0 @@
-/vendor/firmware


### PR DESCRIPTION
[configs] Remove firmware symbolic links. JB#46848

We can remove these symlinks after this fix:
https://github.com/mer-hybris/droid-hal-configs/commit/249c4f0f79a598e9b78e2a28d1768bba16ce58a5

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>