### PR TITLE
configs: Add hwcomposer services for encryption unlocking ui.

### DIFF
--- a/sparse/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-1.conf
@@ -1,0 +1,6 @@
+[Service]
+# stop hwcomposer before unlock ui
+ExecStartPre=-/system/bin/stop vendor.hwcomposer-2-1
+
+# start hwcomposer after unlock ui
+ExecStart=-/system/bin/start vendor.hwcomposer-2-1

--- a/sparse/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-1.conf
@@ -1,0 +1,3 @@
+[Service]
+# make unlock ui exit
+ExecStartPre=/usr/sbin/dummy_compositor


### PR DESCRIPTION
[configs] Add hwcomposer services for encryption unlocking ui. JB#46723

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>