### PR TITLE
configs: Do not start hwcomposer after unlocking ui in upgrade target.

### DIFF
--- a/sparse/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-1.conf
@@ -2,5 +2,5 @@
 # stop hwcomposer before unlock ui
 ExecStartPre=-/system/bin/stop vendor.hwcomposer-2-1
 
-# start hwcomposer after unlock ui
-ExecStart=-/system/bin/start vendor.hwcomposer-2-1
+# start hwcomposer after unlock ui, but not on upgrade target
+ExecStart=-/bin/sh -c '/usr/bin/test -f /tmp/os-update-running || /system/bin/start vendor.hwcomposer-2-1'


### PR DESCRIPTION
[configs] Do not start hwcomposer after unlocking ui in upgrade target. JB#46746

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>