### PR TITLE
Enable query of initial PIN retry count

### DIFF
--- a/sparse/etc/ofono/ril_subscription.conf
+++ b/sparse/etc/ofono/ril_subscription.conf
@@ -7,7 +7,7 @@
 #SetRadioCapability=auto
 
 SetRadioCapability=off
-emptyPinQuery=false
+emptyPinQuery=true
 radioPowerCycle=false
 confirmRadioPowerOn=false
 


### PR DESCRIPTION
It's a Qualcomm specific hack and it seems to work on X10.