### PR TITLE
[configs] Add configuration for touchscreen feedback sound levels. Fixes JB#47563

### DIFF
--- a/sparse/usr/share/ngfd/plugins.d/60-profile.ini
+++ b/sparse/usr/share/ngfd/plugins.d/60-profile.ini
@@ -1,0 +1,3 @@
+[profile]
+touchscreen.sound.level = 0;18;50;75
+


### PR DESCRIPTION
Same values as with f5212 (xperia x) and the end result seems roughly the same too.

@jusa 

Disclaimer: haven't tested building etc due to related complications with these packages. Tested by having the file on the device.

A little thinking if the default should be made lower as this happens for all the devices. Or then higher to really push device specific configuration to be made :) 