### PR TITLE
[radio] remove the now obsolete modem workaround. JB#48074

### DIFF
--- a/sparse/lib/systemd/system/fixup_ril.service
+++ b/sparse/lib/systemd/system/fixup_ril.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Telephony fixup service
-Before=droid-hal-init.service
+After=droid-hal-init.service
 DefaultDependencies=no
 
 [Service]

--- a/sparse/usr/bin/droid/fixup_ril.sh
+++ b/sparse/usr/bin/droid/fixup_ril.sh
@@ -1,17 +1,14 @@
 #!/bin/sh
 
-mkdir -p /dev/socket/qmux_radio/rild_sync_1
-
-# single sim workaround
-(
-
+# Restore single sim devices after removal of the modem workaround.
 if [ "$(grep -o persist.vendor.radio.multisim.config=dsds /vendor/build.prop)" != "persist.vendor.radio.multisim.config=dsds" ]; then
     while [ "$(pidof rild)" == "" ]; do
         echo "Waiting for rild"
         sleep 1
     done
 
+    /system/bin/stop vendor.ril-daemon2
+    setprop persist.vendor.radio.multisim.config ""
     setprop persist.radio.multisim.config ""
 fi
 
-) &

--- a/sparse/usr/libexec/droid-hybris/system/etc/init/fixup_ril.rc
+++ b/sparse/usr/libexec/droid-hybris/system/etc/init/fixup_ril.rc
@@ -1,3 +1,0 @@
-on boot
-    # single sim workaround
-    setprop persist.vendor.radio.multisim.config dsds


### PR DESCRIPTION
Since the property we changed is persistent we need to make sure it is unset on single sim devices even after the workaround has been removed.