### PR TITLE
Pull in nfcd-dbuslog-plugin

### DIFF
--- a/patterns/jolla-configuration-i3113.yaml
+++ b/patterns/jolla-configuration-i3113.yaml
@@ -17,12 +17,16 @@ Requires:
 
 - sailfish-content-graphics-z@ICON_RES@
 
-- jolla-settings-system-nfc
 - jolla-settings-system-flashlight
 
 - geoclue-provider-mlsdb
 - csd
 - mapplauncherd-booster-silica-qt5-media
+
+# NFC
+- nfcd-mce-plugin
+- nfcd-dbuslog-plugin
+- jolla-settings-system-nfc
 
 Summary: Jolla Configuration i3113
 

--- a/patterns/jolla-configuration-i3213.yaml
+++ b/patterns/jolla-configuration-i3213.yaml
@@ -17,12 +17,16 @@ Requires:
 
 - sailfish-content-graphics-z@ICON_RES@
 
-- jolla-settings-system-nfc
 - jolla-settings-system-flashlight
 
 - geoclue-provider-mlsdb
 - csd
 - mapplauncherd-booster-silica-qt5-media
+
+# NFC
+- nfcd-mce-plugin
+- nfcd-dbuslog-plugin
+- jolla-settings-system-nfc
 
 Summary: Jolla Configuration i3213
 

--- a/patterns/jolla-configuration-i4113.yaml
+++ b/patterns/jolla-configuration-i4113.yaml
@@ -18,12 +18,16 @@ Requires:
 - sailfish-content-graphics-z@ICON_RES@
 
 - jolla-settings-networking-multisim
-- jolla-settings-system-nfc
 - jolla-settings-system-flashlight
 
 - geoclue-provider-mlsdb
 - csd
 - mapplauncherd-booster-silica-qt5-media
+
+# NFC
+- nfcd-mce-plugin
+- nfcd-dbuslog-plugin
+- jolla-settings-system-nfc
 
 Summary: Jolla Configuration i4113
 

--- a/patterns/jolla-configuration-i4213.yaml
+++ b/patterns/jolla-configuration-i4213.yaml
@@ -18,12 +18,16 @@ Requires:
 - sailfish-content-graphics-z@ICON_RES@
 
 - jolla-settings-networking-multisim
-- jolla-settings-system-nfc
 - jolla-settings-system-flashlight
 
 - geoclue-provider-mlsdb
 - csd
 - mapplauncherd-booster-silica-qt5-media
+
+# NFC
+- nfcd-mce-plugin
+- nfcd-dbuslog-plugin
+- jolla-settings-system-nfc
 
 Summary: Jolla Configuration i4213
 

--- a/patterns/jolla-hw-adaptation-kirin.yaml
+++ b/patterns/jolla-hw-adaptation-kirin.yaml
@@ -18,7 +18,6 @@ Requires:
 - ofono-ril-binder-plugin
 
 # NFC
-- nfcd-mce-plugin
 - nfcd-binder-plugin
 
 # Sensors

--- a/patterns/jolla-hw-adaptation-mermaid.yaml
+++ b/patterns/jolla-hw-adaptation-mermaid.yaml
@@ -18,7 +18,6 @@ Requires:
 - ofono-ril-binder-plugin
 
 # NFC
-- nfcd-mce-plugin
 - nfcd-binder-plugin
 
 # Sensors


### PR DESCRIPTION
It used to be a built-in plugin