### PR TITLE
sensors: Enable built-in compass of sensorfw.

### DIFF
--- a/sparse/etc/sensorfw/primaryuse.conf
+++ b/sparse/etc/sensorfw/primaryuse.conf
@@ -3,7 +3,7 @@ accelerometeradaptor = hybrisaccelerometeradaptor
 alsadaptor = hybrisalsadaptor
 proximityadaptor = hybrisproximityadaptor
 magnetometeradaptor = hybrismagnetometeradaptor
-orientationadaptor = hybrisorientationadaptor
+orientationadaptor =
 
 [magnetometer]
 scale_coefficient = 1


### PR DESCRIPTION
[sensors] Enable built-in compass of sensorfw. JB#46853

Requires https://git.sailfishos.org/mer-core/sensorfw/merge_requests/58