### PR TITLE
Nuke yaml patterns

### DIFF
--- a/delete_pattern_i3113.list
+++ b/delete_pattern_i3113.list
@@ -1,3 +1,0 @@
-/usr/share/package-groups/jolla-configuration-i3213.xml
-/usr/share/package-groups/jolla-configuration-i4113.xml
-/usr/share/package-groups/jolla-configuration-i4213.xml

--- a/delete_pattern_i3213.list
+++ b/delete_pattern_i3213.list
@@ -1,3 +1,0 @@
-/usr/share/package-groups/jolla-configuration-i3113.xml
-/usr/share/package-groups/jolla-configuration-i4113.xml
-/usr/share/package-groups/jolla-configuration-i4213.xml

--- a/delete_pattern_i4113.list
+++ b/delete_pattern_i4113.list
@@ -1,3 +1,0 @@
-/usr/share/package-groups/jolla-configuration-i3113.xml
-/usr/share/package-groups/jolla-configuration-i3213.xml
-/usr/share/package-groups/jolla-configuration-i4213.xml

--- a/delete_pattern_i4213.list
+++ b/delete_pattern_i4213.list
@@ -1,3 +1,0 @@
-/usr/share/package-groups/jolla-configuration-i3113.xml
-/usr/share/package-groups/jolla-configuration-i3213.xml
-/usr/share/package-groups/jolla-configuration-i4113.xml

--- a/patterns/jolla-configuration-i3113.yaml
+++ b/patterns/jolla-configuration-i3113.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for i3113 configurations
-Name: jolla-configuration-i3113
-Requires:
-- patterns-sailfish-device-configuration-i3113
-
-Summary: Jolla Configuration i3113
-

--- a/patterns/jolla-configuration-i3213.yaml
+++ b/patterns/jolla-configuration-i3213.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for i3213 configurations
-Name: jolla-configuration-i3213
-Requires:
-- patterns-sailfish-device-configuration-i3213
-
-Summary: Jolla Configuration i3213
-

--- a/patterns/jolla-configuration-i4113.yaml
+++ b/patterns/jolla-configuration-i4113.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for i4113 configurations
-Name: jolla-configuration-i4113
-Requires:
-- patterns-sailfish-device-configuration-i4113
-
-Summary: Jolla Configuration i4113
-

--- a/patterns/jolla-configuration-i4213.yaml
+++ b/patterns/jolla-configuration-i4213.yaml
@@ -1,7 +1,0 @@
-Description: Pattern with packages for i4213 configurations
-Name: jolla-configuration-i4213
-Requires:
-- patterns-sailfish-device-configuration-i4213
-
-Summary: Jolla Configuration i4213
-


### PR DESCRIPTION
[patterns] remove sailfish-porter-tools
[patterns] remove yaml leftovers

Update submodule
[sparse] support vendor-specific versioned sparse
[sparse] support sparse for adaptations that package own /system