### PR TITLE
configs: handle android hwc start/stop via mce

### DIFF
--- a/sparse/etc/mce/60-compositor-ganges.ini
+++ b/sparse/etc/mce/60-compositor-ganges.ini
@@ -1,0 +1,3 @@
+[Compositor]
+StopHwCompositor=/system/bin/stop vendor.hwcomposer-2-1
+StartHwCompositor=/system/bin/start vendor.hwcomposer-2-1

--- a/sparse/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/system/sailfish-unlock-agent.service.d/50-vendor.hwcomposer-2-1.conf
@@ -1,6 +1,0 @@
-[Service]
-# stop hwcomposer before unlock ui
-ExecStartPre=-/system/bin/stop vendor.hwcomposer-2-1
-
-# start hwcomposer after unlock ui, but not on upgrade target
-ExecStart=-/bin/sh -c '/usr/bin/test -f /tmp/os-update-running || /system/bin/start vendor.hwcomposer-2-1'

--- a/sparse/usr/lib/systemd/system/sailfish-upgrade-ui.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/system/sailfish-upgrade-ui.service.d/50-vendor.hwcomposer-2-1.conf
@@ -1,3 +1,0 @@
-[Service]
-# make sure unlock-ui has exited before starting upgrade-ui
-ExecStartPre=-/usr/sbin/dummy_compositor --exit-on-enable

--- a/sparse/usr/lib/systemd/user/jolla-startupwizard-pre-user-session.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/user/jolla-startupwizard-pre-user-session.service.d/50-vendor.hwcomposer-2-1.conf
@@ -1,3 +1,0 @@
-[Service]
-# make unlock ui exit
-ExecStartPre=/usr/sbin/dummy_compositor

--- a/sparse/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-1.conf
+++ b/sparse/usr/lib/systemd/user/lipstick.service.d/50-vendor.hwcomposer-2-1.conf
@@ -1,3 +1,0 @@
-[Service]
-# make unlock ui exit
-ExecStartPre=/usr/sbin/dummy_compositor


### PR DESCRIPTION
Add configuration file for instructing mce how to start/stop hwc.

Adjust systemd service drop-ins to utilize dummy_compositor in such way that makes android hwc available for Qt based UIs under control of mce.

[configs] Handle android hwc start/stop via mce. JB#59917

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>