### PR TITLE
networking: Enable bluetooth tethering on Xperia 10

### DIFF
--- a/sparse/usr/lib/systemd/system/bluetooth.service.d/bt_tethering.conf
+++ b/sparse/usr/lib/systemd/system/bluetooth.service.d/bt_tethering.conf
@@ -1,0 +1,2 @@
+[Service]
+SupplementaryGroups=inet

--- a/sparse/usr/share/csd/settings.d/10-hw-settings.ini
+++ b/sparse/usr/share/csd/settings.d/10-hw-settings.ini
@@ -6,6 +6,7 @@ BackCameraFlash=1
 Backlight=1
 Battery=1
 Bluetooth=1
+BluetoothTethering=1
 CellularData=1
 CellularVoice=1
 ECompass=1


### PR DESCRIPTION
Declare BluetoothTethering as supported in csd config for the Xperia 10. Add 'inet' as supplementary group to bluetooth systemd service to allow tethering when CONFIG_ANDROID_PARANOID_NETWORK is enabled.

[networking] Enable bluetooth tethering on Xperia 10. JB#60489