### PR TITLE
patterns: Require sailfish-fpd

### DIFF
--- a/patterns/patterns-sailfish-device-adaptation-kirin.inc
+++ b/patterns/patterns-sailfish-device-adaptation-kirin.inc
@@ -58,6 +58,7 @@ Requires: rfkill
 
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption

--- a/patterns/patterns-sailfish-device-adaptation-mermaid.inc
+++ b/patterns/patterns-sailfish-device-adaptation-mermaid.inc
@@ -58,6 +58,7 @@ Requires: rfkill
 
 # enable device lock and allow to select untrusted software
 Requires: sailfish-devicelock-fpd
+Requires: sailfish-fpd
 
 # Enable home encryption
 Requires: sailfish-device-encryption


### PR DESCRIPTION
As sailfish-devicelock-fpd no longer explicitly requires sailfish-fpd, it needs to be pulled in via patterns.

[patterns] Require sailfish-fpd. JB#62474